### PR TITLE
updated one_node_fp to use odin_data_adapter

### DIFF
--- a/dev/one_node_fp/odin_server.cfg
+++ b/dev/one_node_fp/odin_server.cfg
@@ -13,7 +13,8 @@ endpoints = 127.0.0.1:10000
 update_interval = 0.2
 
 [adapter.fp]
-module = odin_data.control.frame_processor_adapter.FrameProcessorAdapter
+module = odin_data.control.odin_data_adapter.OdinDataAdapter
+frame_processor = true
 endpoints = 127.0.0.1:10004
 update_interval = 0.2
 


### PR DESCRIPTION
Updated one_node_fp odin_server.cfg to use the most up to date version of the odin_data_adapter.
two_node_fp was already updated.